### PR TITLE
Manage firrtl dependency manually.

### DIFF
--- a/common/Makefrag
+++ b/common/Makefrag
@@ -67,7 +67,11 @@ src/tcl/make_bitstream_$(CONFIG).tcl: $(common)/make_bitstream.tcl
 	sed 's/BOARD_NAME_HERE/$(BOARD)/g;s/CHISEL_CONFIG_HERE/$(CONFIG)/g' \
 		$(common)/make_bitstream.tcl > src/tcl/make_bitstream_$(CONFIG).tcl
 
-$(rocketchip_stamp): $(call lookup_scala_srcs, $(ROCKET_DIR))
+$(ROCKET_DIR)/lib/firrtl.jar: $(FIRRTL_JAR)
+	mkdir -p $(@D)
+	cp $< $@
+
+$(rocketchip_stamp): $(call lookup_scala_srcs, $(ROCKET_DIR)) $(ROCKET_DIR)/lib/firrtl.jar
 	cd $(ROCKET_DIR) && $(SBT) pack
 	mkdir -p $(common)/lib
 	cp $(ROCKET_DIR)/target/pack/lib/* $(common)/lib


### PR DESCRIPTION
This is needed to fix firrtl sbt dependency check failing on a fresh repo clone.

Copied from @davidbiancolin PR #41 from upstream.